### PR TITLE
Update generate-unity-license.yml

### DIFF
--- a/.github/workflows/generate-unity-license.yml
+++ b/.github/workflows/generate-unity-license.yml
@@ -7,12 +7,12 @@ jobs:
     name: Request manual activation file 🔑
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: game-ci/unity-request-activation-file@v2
         id: getManualLicenseFile
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Manual Activation File
           path: ${{ steps.getManualLicenseFile.outputs.filePath }}


### PR DESCRIPTION
The current Unity license generation file is not up to date, and this has been fixed now.